### PR TITLE
iOS platform abstraction + WebKit PSNR comparison test

### DIFF
--- a/Framework/IJSVG/IJSVG.xcodeproj/project.pbxproj
+++ b/Framework/IJSVG/IJSVG.xcodeproj/project.pbxproj
@@ -167,6 +167,10 @@
 		59FDBF0127F3454800AF7038 /* IJSVGColorNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 59FDBEFF27F3454800AF7038 /* IJSVGColorNode.m */; };
 		59FE8E4328C7E70800AB38B3 /* IJSVGStop.m in Sources */ = {isa = PBXBuildFile; fileRef = 59FE8E4128C7E70800AB38B3 /* IJSVGStop.m */; };
 		59FE8E4428C7E70800AB38B3 /* IJSVGStop.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FE8E4228C7E70800AB38B3 /* IJSVGStop.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF16B67F2DF54870ACC269EB /* IJSVGPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C744AB801E4A33A65F5FF9 /* IJSVGPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F22B4C3C3CBA42FB8C5C1B44 /* IJSVGPlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = EC97155115A24F3693672BA8 /* IJSVGPlatform.m */; };
+		3C92E7F8C2404360B1CA60CC /* IJSVGiOSXML.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BE68F2FE1042A6A774588A /* IJSVGiOSXML.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EA0DEAFD1674E288FF54A0A /* IJSVGiOSXML.m in Sources */ = {isa = PBXBuildFile; fileRef = 2125406112FA4571A50989E8 /* IJSVGiOSXML.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -333,6 +337,10 @@
 		59FDBEFF27F3454800AF7038 /* IJSVGColorNode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IJSVGColorNode.m; sourceTree = "<group>"; };
 		59FE8E4128C7E70800AB38B3 /* IJSVGStop.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IJSVGStop.m; sourceTree = "<group>"; };
 		59FE8E4228C7E70800AB38B3 /* IJSVGStop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IJSVGStop.h; sourceTree = "<group>"; };
+		E3C744AB801E4A33A65F5FF9 /* IJSVGPlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IJSVGPlatform.h; sourceTree = "<group>"; };
+		EC97155115A24F3693672BA8 /* IJSVGPlatform.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IJSVGPlatform.m; sourceTree = "<group>"; };
+		F9BE68F2FE1042A6A774588A /* IJSVGiOSXML.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IJSVGiOSXML.h; sourceTree = "<group>"; };
+		2125406112FA4571A50989E8 /* IJSVGiOSXML.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IJSVGiOSXML.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -625,6 +633,10 @@
 				59EB75CD23905F7200F5AE63 /* IJSVGView.h */,
 				59EB75C123905F7100F5AE63 /* IJSVGView.m */,
 				595FD12E29EC56BA00666897 /* IJSVGUmbrella.h */,
+				E3C744AB801E4A33A65F5FF9 /* IJSVGPlatform.h */,
+				EC97155115A24F3693672BA8 /* IJSVGPlatform.m */,
+				F9BE68F2FE1042A6A774588A /* IJSVGiOSXML.h */,
+				2125406112FA4571A50989E8 /* IJSVGiOSXML.m */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -733,6 +745,8 @@
 				5955731F286C643900156047 /* IJSVGTileLayer.h in Headers */,
 				59DB84E028C9F70000A9696A /* IJSVGBitFlags64.h in Headers */,
 				59EB760B23905F7300F5AE63 /* IJSVGStyleSheetSelector.h in Headers */,
+				BF16B67F2DF54870ACC269EB /* IJSVGPlatform.h in Headers */,
+				3C92E7F8C2404360B1CA60CC /* IJSVGiOSXML.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -882,6 +896,8 @@
 				59EB75F123905F7300F5AE63 /* IJSVGUtils.m in Sources */,
 				59EB760A23905F7300F5AE63 /* IJSVGCommandMove.m in Sources */,
 				59EB761B23905F7300F5AE63 /* IJSVGPattern.m in Sources */,
+				F22B4C3C3CBA42FB8C5C1B44 /* IJSVGPlatform.m in Sources */,
+				3EA0DEAFD1674E288FF54A0A /* IJSVGiOSXML.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Framework/IJSVG/IJSVG/Source/Colors/IJSVGColor.h
+++ b/Framework/IJSVG/IJSVG/Source/Colors/IJSVGColor.h
@@ -6,8 +6,7 @@
 //  Copyright (c) 2014 Curtis Hard. All rights reserved.
 //
 
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
+#import <IJSVG/IJSVGPlatform.h>
 
 typedef NS_OPTIONS(NSInteger, IJSVGColorStringOptions) {
     IJSVGColorStringOptionNone = 1 << 0,

--- a/Framework/IJSVG/IJSVG/Source/Colors/IJSVGTraitedColor.h
+++ b/Framework/IJSVG/IJSVG/Source/Colors/IJSVGTraitedColor.h
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Curtis Hard. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import <AppKit/AppKit.h>
+#import <IJSVG/IJSVGPlatform.h>
 
 typedef NS_OPTIONS(NSInteger, IJSVGColorUsageTraits) {
     IJSVGColorUsageTraitNone = 0,

--- a/Framework/IJSVG/IJSVG/Source/Core/IJSVG.h
+++ b/Framework/IJSVG/IJSVG/Source/Core/IJSVG.h
@@ -18,7 +18,7 @@
 #import <IJSVG/IJSVGRendering.h>
 #import <IJSVG/IJSVGStyle.h>
 #import <IJSVG/IJSVGTransaction.h>
-#import <Foundation/Foundation.h>
+#import <IJSVG/IJSVGPlatform.h>
 
 @class IJSVG;
 @class IJSVGParser;

--- a/Framework/IJSVG/IJSVG/Source/Core/IJSVGPlatform.h
+++ b/Framework/IJSVG/IJSVG/Source/Core/IJSVGPlatform.h
@@ -1,0 +1,71 @@
+//
+//  IJSVGPlatform.h
+//  IJSVG
+//
+//  Platform abstraction for shared macOS / iOS code.
+//
+
+#import <TargetConditionals.h>
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_OSX
+
+#import <AppKit/AppKit.h>
+
+static inline CGContextRef NSGraphicsGetCurrentContext(void) {
+    return NSGraphicsContext.currentContext.CGContext;
+}
+
+#elif TARGET_OS_IOS
+
+#import <UIKit/UIKit.h>
+#import <IJSVG/IJSVGiOSXML.h>
+
+#define NSColor UIColor
+#define NSImage UIImage
+#define NSBezierPath UIBezierPath
+#define NSEdgeInsets UIEdgeInsets
+#define NSEdgeInsetsZero UIEdgeInsetsZero
+#define NSFont UIFont
+#define NSView UIView
+#define NSGraphicsGetCurrentContext() UIGraphicsGetCurrentContext()
+
+typedef CGPoint NSPoint;
+typedef CGSize NSSize;
+typedef CGRect NSRect;
+
+#define NSZeroPoint CGPointZero
+#define NSZeroSize CGSizeZero
+#define NSZeroRect CGRectZero
+#define NSMakePoint(x, y) CGPointMake((x), (y))
+#define NSMakeSize(w, h) CGSizeMake((w), (h))
+#define NSMakeRect(x, y, w, h) CGRectMake((x), (y), (w), (h))
+
+// On macOS NSRect is typedef'd to CGRect, so the conversion functions are
+// identity. On iOS NSRect doesn't exist natively — we typedef it to CGRect
+// above, so the same identity rule applies. Same for Point/Size.
+#define NSRectFromCGRect(r) (r)
+#define NSRectToCGRect(r) (r)
+#define NSPointFromCGPoint(p) (p)
+#define NSPointToCGPoint(p) (p)
+#define NSSizeFromCGSize(s) (s)
+#define NSSizeToCGSize(s) (s)
+
+// AppKit's -[NSView setNeedsDisplay:] takes a BOOL; UIKit's takes none.
+// Provide a BOOL-taking variant so shared call sites compile unchanged.
+@interface UIView (IJSVGNeedsDisplay)
+- (void)setNeedsDisplay:(BOOL)flag;
+@end
+
+// Foundation on iOS only ships the CG-named NSValue geometry methods; AppKit
+// uses the NS-named ones. Bridge them so cross-platform call sites work.
+@interface NSValue (IJSVGGeometry)
++ (NSValue*)valueWithPoint:(CGPoint)point;
++ (NSValue*)valueWithSize:(CGSize)size;
++ (NSValue*)valueWithRect:(CGRect)rect;
+@property (readonly) CGPoint pointValue;
+@property (readonly) CGSize sizeValue;
+@property (readonly) CGRect rectValue;
+@end
+
+#endif

--- a/Framework/IJSVG/IJSVG/Source/Core/IJSVGPlatform.m
+++ b/Framework/IJSVG/IJSVG/Source/Core/IJSVGPlatform.m
@@ -1,0 +1,32 @@
+//
+//  IJSVGPlatform.m
+//  IJSVG
+//
+
+#import "IJSVGPlatform.h"
+
+#if TARGET_OS_IOS
+
+@implementation UIView (IJSVGNeedsDisplay)
+
+- (void)setNeedsDisplay:(BOOL)flag
+{
+    if(flag) {
+        [self setNeedsDisplay];
+    }
+}
+
+@end
+
+@implementation NSValue (IJSVGGeometry)
+
++ (NSValue*)valueWithPoint:(CGPoint)point { return [NSValue valueWithCGPoint:point]; }
++ (NSValue*)valueWithSize:(CGSize)size { return [NSValue valueWithCGSize:size]; }
++ (NSValue*)valueWithRect:(CGRect)rect { return [NSValue valueWithCGRect:rect]; }
+- (CGPoint)pointValue { return [self CGPointValue]; }
+- (CGSize)sizeValue { return [self CGSizeValue]; }
+- (CGRect)rectValue { return [self CGRectValue]; }
+
+@end
+
+#endif

--- a/Framework/IJSVG/IJSVG/Source/Core/IJSVGUmbrella.h
+++ b/Framework/IJSVG/IJSVG/Source/Core/IJSVGUmbrella.h
@@ -29,9 +29,11 @@
 #import <IJSVG/IJSVGMath.h>
 #import <IJSVG/IJSVGParsing.h>
 #import <IJSVG/IJSVGPatternLayer.h>
+#import <IJSVG/IJSVGPlatform.h>
 #import <IJSVG/IJSVGStrokeLayer.h>
 #import <IJSVG/IJSVGThreadManager.h>
 #import <IJSVG/IJSVGView.h>
 #import <IJSVG/NSImage+IJSVGAdditions.h>
+#import <IJSVG/IJSVGiOSXML.h>
 
 #endif /* IJSVGUmbrella_h */

--- a/Framework/IJSVG/IJSVG/Source/Core/IJSVGiOSXML.h
+++ b/Framework/IJSVG/IJSVG/Source/Core/IJSVGiOSXML.h
@@ -1,0 +1,106 @@
+//
+//  IJSVGiOSXML.h
+//  IJSVG
+//
+
+#import <Foundation/Foundation.h>
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IOS
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_OPTIONS(NSUInteger, NSXMLNodeOptions) {
+    NSXMLNodeOptionsNone = 0,
+    NSXMLNodePrettyPrint = 1UL << 0,
+    NSXMLNodeCompactEmptyElement = 1UL << 1
+};
+
+typedef NS_ENUM(NSUInteger, NSXMLNodeKind) {
+    NSXMLInvalidKind = 0,
+    NSXMLDocumentKind = 1,
+    NSXMLElementKind = 2,
+    NSXMLAttributeKind = 3,
+    NSXMLTextKind = 4,
+    NSXMLCommentKind = 5
+};
+
+@class IJSVGiOSXMLDocument;
+@class IJSVGiOSXMLElement;
+
+@interface IJSVGiOSXMLNode : NSObject <NSCopying>
+
+@property (nonatomic, assign) NSXMLNodeKind kind;
+@property (nonatomic, copy, nullable) NSString* name;
+@property (nonatomic, copy, nullable) NSString* localName;
+@property (nonatomic, copy, nullable) NSString* URI;
+@property (nonatomic, copy, nullable) NSString* stringValue;
+@property (nonatomic, weak, nullable) id parent;
+@property (nonatomic, weak, nullable) IJSVGiOSXMLDocument* document;
+@property (nonatomic, readonly, nullable) NSArray<IJSVGiOSXMLNode*>* attributes;
+@property (nonatomic, readonly, nullable) NSArray<IJSVGiOSXMLNode*>* children;
+@property (nonatomic, readonly) NSUInteger childCount;
+@property (nonatomic, readonly) NSUInteger index;
+@property (nonatomic, readonly, nullable) IJSVGiOSXMLNode* nextSibling;
+
+- (instancetype)initWithKind:(NSXMLNodeKind)kind;
+- (nullable IJSVGiOSXMLNode*)attributeForName:(NSString*)name;
+- (nullable IJSVGiOSXMLNode*)attributeForLocalName:(NSString*)localName
+                                            URI:(nullable NSString*)URI;
+- (void)detach;
+
+@end
+
+@interface IJSVGiOSXMLElement : IJSVGiOSXMLNode
+
+@property (nonatomic, readonly) NSArray<IJSVGiOSXMLNode*>* attributes;
+@property (nonatomic, readonly) NSArray<IJSVGiOSXMLNode*>* children;
+@property (nonatomic, readonly) NSUInteger childCount;
+
+- (instancetype)initWithName:(nullable NSString*)name;
+- (nullable IJSVGiOSXMLNode*)attributeForName:(NSString*)name;
+- (nullable IJSVGiOSXMLNode*)attributeForLocalName:(NSString*)localName
+                                            URI:(nullable NSString*)URI;
+- (void)setAttributesAsDictionary:(NSDictionary<NSString*, NSString*>*)attributes;
+- (void)addAttribute:(IJSVGiOSXMLNode*)attribute;
+- (void)removeAttributeForName:(NSString*)name;
+- (void)addChild:(IJSVGiOSXMLNode*)child;
+- (void)setChildren:(nullable NSArray<IJSVGiOSXMLNode*>*)children;
+- (void)insertChild:(IJSVGiOSXMLNode*)child
+            atIndex:(NSUInteger)index;
+- (void)removeChildAtIndex:(NSUInteger)index;
+- (void)replaceChildAtIndex:(NSUInteger)index
+                   withNode:(IJSVGiOSXMLNode*)node;
+
+@end
+
+@interface IJSVGiOSXMLDocument : NSObject
+
+@property (nonatomic, copy, nullable) NSString* version;
+@property (nonatomic, copy, nullable) NSString* characterEncoding;
+@property (nonatomic, strong, nullable) IJSVGiOSXMLElement* rootElement;
+@property (nonatomic, readonly) id rootDocument;
+
+- (instancetype)initWithRootElement:(IJSVGiOSXMLElement*)rootElement;
+- (instancetype)initWithXMLString:(NSString*)string
+                           options:(NSXMLNodeOptions)options
+                             error:(NSError**)error;
+- (instancetype)initWithData:(NSData*)data
+                      options:(NSXMLNodeOptions)options
+                        error:(NSError**)error;
+- (instancetype)initWithContentsOfURL:(NSURL*)URL
+                               options:(NSXMLNodeOptions)options
+                                 error:(NSError**)error;
+- (NSArray<IJSVGiOSXMLElement*>*)nodesForXPath:(NSString*)xPath
+                                      error:(NSError**)error;
+- (NSString*)XMLStringWithOptions:(NSXMLNodeOptions)options;
+
+@end
+
+typedef IJSVGiOSXMLNode NSXMLNode;
+typedef IJSVGiOSXMLElement NSXMLElement;
+typedef IJSVGiOSXMLDocument NSXMLDocument;
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Framework/IJSVG/IJSVG/Source/Core/IJSVGiOSXML.m
+++ b/Framework/IJSVG/IJSVG/Source/Core/IJSVGiOSXML.m
@@ -1,0 +1,759 @@
+//
+//  IJSVGiOSXML.m
+//  IconJar
+//
+//  Created by Curtis Hard on 30/08/2014.
+//  Copyright (c) 2014 Curtis Hard. All rights reserved.
+//
+
+#import "IJSVGiOSXML.h"
+
+#if TARGET_OS_IOS
+#import <libxml/parser.h>
+#import <libxml/tree.h>
+
+static NSString* IJSVGiOSXMLStringFromXMLChar(const xmlChar* chars)
+{
+    if(chars == NULL) {
+        return nil;
+    }
+    return [NSString stringWithUTF8String:(const char*)chars];
+}
+
+static NSString* IJSVGiOSXMLQualifiedName(NSString* localName, NSString* prefix)
+{
+    if(prefix.length == 0 || localName.length == 0) {
+        return localName;
+    }
+    return [NSString stringWithFormat:@"%@:%@", prefix, localName];
+}
+
+static NSString* IJSVGiOSXMLEscapeString(NSString* string, BOOL isAttribute)
+{
+    if(string.length == 0) {
+        return @"";
+    }
+    NSMutableString* output = [string mutableCopy];
+    [output replaceOccurrencesOfString:@"&"
+                            withString:@"&amp;"
+                               options:0
+                                 range:NSMakeRange(0, output.length)];
+    [output replaceOccurrencesOfString:@"<"
+                            withString:@"&lt;"
+                               options:0
+                                 range:NSMakeRange(0, output.length)];
+    [output replaceOccurrencesOfString:@">"
+                            withString:@"&gt;"
+                               options:0
+                                 range:NSMakeRange(0, output.length)];
+    if(isAttribute == YES) {
+        [output replaceOccurrencesOfString:@"\""
+                                withString:@"&quot;"
+                                   options:0
+                                     range:NSMakeRange(0, output.length)];
+    }
+    return output;
+}
+
+@interface IJSVGiOSXMLElement ()
+
+@property (nonatomic, strong) NSMutableArray<NSXMLNode*>* mutableAttributes;
+@property (nonatomic, strong) NSMutableArray<NSXMLNode*>* mutableChildren;
+
+@end
+
+@implementation IJSVGiOSXMLNode
+
+- (instancetype)init
+{
+    return [self initWithKind:NSXMLInvalidKind];
+}
+
+- (instancetype)initWithKind:(NSXMLNodeKind)kind
+{
+    if((self = [super init]) != nil) {
+        _kind = kind;
+    }
+    return self;
+}
+
+- (void)setName:(NSString*)name
+{
+    _name = [name copy];
+    if(_name == nil) {
+        _localName = nil;
+        return;
+    }
+    NSRange range = [_name rangeOfString:@":" options:NSBackwardsSearch];
+    _localName = (range.location == NSNotFound) ? _name : [_name substringFromIndex:(range.location + 1)];
+}
+
+- (NSUInteger)index
+{
+    if([_parent isKindOfClass:[NSXMLElement class]] == YES) {
+        NSXMLElement* element = (NSXMLElement*)_parent;
+        NSArray<NSXMLNode*>* nodes = (_kind == NSXMLAttributeKind) ? element.attributes : element.children;
+        NSUInteger idx = [nodes indexOfObjectIdenticalTo:self];
+        return idx == NSNotFound ? NSNotFound : idx;
+    }
+    if([_parent isKindOfClass:[NSXMLDocument class]] == YES) {
+        NSXMLDocument* doc = (NSXMLDocument*)_parent;
+        if(doc.rootElement == (NSXMLElement*)self) {
+            return 0;
+        }
+    }
+    return NSNotFound;
+}
+
+- (NSArray<NSXMLNode*>*)attributes
+{
+    return @[];
+}
+
+- (NSArray<NSXMLNode*>*)children
+{
+    return @[];
+}
+
+- (NSUInteger)childCount
+{
+    return 0;
+}
+
+- (NSXMLNode*)attributeForName:(NSString*)name
+{
+    return nil;
+}
+
+- (NSXMLNode*)attributeForLocalName:(NSString*)localName
+                                URI:(NSString* _Nullable)URI
+{
+    return nil;
+}
+
+- (NSXMLNode*)nextSibling
+{
+    if([_parent isKindOfClass:[NSXMLElement class]] == NO) {
+        return nil;
+    }
+    NSXMLElement* element = (NSXMLElement*)_parent;
+    NSUInteger idx = self.index;
+    if(idx == NSNotFound || idx + 1 >= element.children.count) {
+        return nil;
+    }
+    return element.children[idx + 1];
+}
+
+- (void)detach
+{
+    if([_parent isKindOfClass:[NSXMLElement class]] == YES) {
+        NSXMLElement* parent = (NSXMLElement*)_parent;
+        if(_kind == NSXMLAttributeKind) {
+            [parent removeAttributeForName:self.name];
+        } else {
+            NSUInteger idx = self.index;
+            if(idx != NSNotFound) {
+                [parent removeChildAtIndex:idx];
+            }
+        }
+        return;
+    }
+    if([_parent isKindOfClass:[NSXMLDocument class]] == YES) {
+        NSXMLDocument* doc = (NSXMLDocument*)_parent;
+        if(doc.rootElement == (NSXMLElement*)self) {
+            doc.rootElement = nil;
+        }
+    }
+}
+
+- (id)copyWithZone:(NSZone*)zone
+{
+    IJSVGiOSXMLNode* copy = [[self.class allocWithZone:zone] initWithKind:_kind];
+    copy.name = _name;
+    copy.localName = _localName;
+    copy.URI = _URI;
+    copy.stringValue = _stringValue;
+    return copy;
+}
+
+@end
+
+@implementation IJSVGiOSXMLElement
+
+- (instancetype)init
+{
+    return [self initWithName:nil];
+}
+
+- (instancetype)initWithName:(NSString*)name
+{
+    if((self = [super initWithKind:NSXMLElementKind]) != nil) {
+        _mutableAttributes = [[NSMutableArray alloc] init];
+        _mutableChildren = [[NSMutableArray alloc] init];
+        self.name = name;
+    }
+    return self;
+}
+
+- (void)setDocument:(NSXMLDocument*)document
+{
+    [super setDocument:document];
+    for(NSXMLNode* attribute in _mutableAttributes) {
+        attribute.document = document;
+    }
+    for(NSXMLNode* child in _mutableChildren) {
+        child.document = document;
+    }
+}
+
+- (NSArray<NSXMLNode*>*)attributes
+{
+    return [_mutableAttributes copy];
+}
+
+- (NSArray<NSXMLNode*>*)children
+{
+    return [_mutableChildren copy];
+}
+
+- (NSUInteger)childCount
+{
+    return _mutableChildren.count;
+}
+
+- (NSXMLNode*)attributeForName:(NSString*)name
+{
+    if(name.length == 0) {
+        return nil;
+    }
+    for(NSXMLNode* node in _mutableAttributes) {
+        if([node.name isEqualToString:name] == YES) {
+            return node;
+        }
+    }
+    return nil;
+}
+
+- (NSXMLNode*)attributeForLocalName:(NSString*)localName
+                                URI:(NSString* _Nullable)URI
+{
+    if(localName.length == 0) {
+        return nil;
+    }
+    for(NSXMLNode* node in _mutableAttributes) {
+        BOOL localMatch = [node.localName isEqualToString:localName];
+        BOOL uriMatch = (URI == nil && node.URI == nil) || [node.URI isEqualToString:URI];
+        if(localMatch == YES && uriMatch == YES) {
+            return node;
+        }
+    }
+    return nil;
+}
+
+- (void)setAttributesAsDictionary:(NSDictionary<NSString*, NSString*>*)attributes
+{
+    if(attributes.count == 0) {
+        return;
+    }
+    NSArray<NSString*>* keys = [attributes.allKeys sortedArrayUsingSelector:@selector(compare:)];
+    for(NSString* key in keys) {
+        NSString* value = attributes[key];
+        if(value == nil) {
+            continue;
+        }
+        NSXMLNode* node = [[NSXMLNode alloc] initWithKind:NSXMLAttributeKind];
+        node.name = key;
+        node.stringValue = value;
+        [self addAttribute:node];
+    }
+}
+
+- (void)addAttribute:(NSXMLNode*)attribute
+{
+    if(attribute == nil) {
+        return;
+    }
+    attribute.kind = NSXMLAttributeKind;
+    if(attribute.name.length != 0) {
+        [self removeAttributeForName:attribute.name];
+    }
+    attribute.parent = self;
+    attribute.document = self.document;
+    [_mutableAttributes addObject:attribute];
+}
+
+- (void)removeAttributeForName:(NSString*)name
+{
+    if(name.length == 0) {
+        return;
+    }
+    NSIndexSet* indexes = [_mutableAttributes indexesOfObjectsPassingTest:^BOOL(NSXMLNode* _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
+        return [obj.name isEqualToString:name];
+    }];
+    if(indexes.count == 0) {
+        return;
+    }
+    NSArray<NSXMLNode*>* removing = [_mutableAttributes objectsAtIndexes:indexes];
+    [_mutableAttributes removeObjectsAtIndexes:indexes];
+    for(NSXMLNode* node in removing) {
+        node.parent = nil;
+        node.document = nil;
+    }
+}
+
+- (void)addChild:(NSXMLNode*)child
+{
+    [self insertChild:child
+              atIndex:_mutableChildren.count];
+}
+
+- (void)setChildren:(NSArray<NSXMLNode*>*)children
+{
+    for(NSXMLNode* child in _mutableChildren) {
+        child.parent = nil;
+        child.document = nil;
+    }
+    [_mutableChildren removeAllObjects];
+    for(NSXMLNode* child in children) {
+        [self addChild:child];
+    }
+}
+
+- (void)insertChild:(NSXMLNode*)child
+            atIndex:(NSUInteger)index
+{
+    if(child == nil) {
+        return;
+    }
+    if(child.kind == NSXMLAttributeKind) {
+        [self addAttribute:child];
+        return;
+    }
+    child.parent = self;
+    child.document = self.document;
+    NSUInteger insertIndex = MIN(index, _mutableChildren.count);
+    [_mutableChildren insertObject:child
+                           atIndex:insertIndex];
+}
+
+- (void)removeChildAtIndex:(NSUInteger)index
+{
+    if(index >= _mutableChildren.count) {
+        return;
+    }
+    NSXMLNode* child = _mutableChildren[index];
+    [_mutableChildren removeObjectAtIndex:index];
+    child.parent = nil;
+    child.document = nil;
+}
+
+- (void)replaceChildAtIndex:(NSUInteger)index
+                   withNode:(NSXMLNode*)node
+{
+    if(index >= _mutableChildren.count || node == nil) {
+        return;
+    }
+    if(node.kind == NSXMLAttributeKind) {
+        return;
+    }
+    NSXMLNode* oldNode = _mutableChildren[index];
+    oldNode.parent = nil;
+    oldNode.document = nil;
+    node.parent = self;
+    node.document = self.document;
+    _mutableChildren[index] = node;
+}
+
+- (NSString*)stringValue
+{
+    if([super stringValue] != nil) {
+        return [super stringValue];
+    }
+    NSMutableString* output = nil;
+    for(NSXMLNode* child in _mutableChildren) {
+        NSString* value = child.stringValue;
+        if(value.length == 0) {
+            continue;
+        }
+        if(output == nil) {
+            output = [[NSMutableString alloc] init];
+        }
+        [output appendString:value];
+    }
+    return output;
+}
+
+- (id)copyWithZone:(NSZone*)zone
+{
+    NSXMLElement* copy = [[self.class allocWithZone:zone] initWithName:self.name];
+    copy.localName = self.localName;
+    copy.URI = self.URI;
+    copy.stringValue = [super stringValue];
+    for(NSXMLNode* attribute in _mutableAttributes) {
+        [copy addAttribute:attribute.copy];
+    }
+    for(NSXMLNode* child in _mutableChildren) {
+        [copy addChild:child.copy];
+    }
+    return copy;
+}
+
+@end
+
+static BOOL IJSVGiOSXMLNodeIsElement(NSXMLNode* node)
+{
+    return [node isKindOfClass:[NSXMLElement class]] == YES && node.kind == NSXMLElementKind;
+}
+
+static void IJSVGiOSXMLVisitElements(NSXMLElement* element, void (^visitor)(NSXMLElement* _Nonnull))
+{
+    visitor(element);
+    for(NSXMLNode* child in element.children) {
+        if(IJSVGiOSXMLNodeIsElement(child) == NO) {
+            continue;
+        }
+        IJSVGiOSXMLVisitElements((NSXMLElement*)child, visitor);
+    }
+}
+
+static NSXMLNode* IJSVGiOSXMLNodeFromLibXMLNode(xmlNodePtr node, xmlDocPtr doc)
+{
+    if(node == NULL) {
+        return nil;
+    }
+    switch(node->type) {
+        case XML_ELEMENT_NODE: {
+            NSString* localName = IJSVGiOSXMLStringFromXMLChar(node->name);
+            NSString* prefix = IJSVGiOSXMLStringFromXMLChar(node->ns == NULL ? NULL : node->ns->prefix);
+            NSString* qualifiedName = IJSVGiOSXMLQualifiedName(localName, prefix);
+            NSXMLElement* element = [[NSXMLElement alloc] initWithName:qualifiedName];
+            element.localName = localName;
+            element.URI = IJSVGiOSXMLStringFromXMLChar(node->ns == NULL ? NULL : node->ns->href);
+
+            for(xmlAttrPtr attr = node->properties; attr != NULL; attr = attr->next) {
+                NSXMLNode* attribute = [[NSXMLNode alloc] initWithKind:NSXMLAttributeKind];
+                NSString* attrLocalName = IJSVGiOSXMLStringFromXMLChar(attr->name);
+                NSString* attrPrefix = IJSVGiOSXMLStringFromXMLChar(attr->ns == NULL ? NULL : attr->ns->prefix);
+                attribute.name = IJSVGiOSXMLQualifiedName(attrLocalName, attrPrefix);
+                attribute.localName = attrLocalName;
+                attribute.URI = IJSVGiOSXMLStringFromXMLChar(attr->ns == NULL ? NULL : attr->ns->href);
+                xmlChar* value = xmlNodeListGetString(doc, attr->children, 1);
+                attribute.stringValue = IJSVGiOSXMLStringFromXMLChar(value);
+                if(value != NULL) {
+                    xmlFree(value);
+                }
+                [element addAttribute:attribute];
+            }
+
+            for(xmlNodePtr child = node->children; child != NULL; child = child->next) {
+                NSXMLNode* childNode = IJSVGiOSXMLNodeFromLibXMLNode(child, doc);
+                if(childNode != nil) {
+                    [element addChild:childNode];
+                }
+            }
+            return element;
+        }
+        case XML_TEXT_NODE:
+        case XML_CDATA_SECTION_NODE: {
+            NSXMLNode* textNode = [[NSXMLNode alloc] initWithKind:NSXMLTextKind];
+            textNode.stringValue = IJSVGiOSXMLStringFromXMLChar(node->content);
+            return textNode;
+        }
+        case XML_COMMENT_NODE: {
+            NSXMLNode* commentNode = [[NSXMLNode alloc] initWithKind:NSXMLCommentKind];
+            commentNode.stringValue = IJSVGiOSXMLStringFromXMLChar(node->content);
+            return commentNode;
+        }
+        default:
+            break;
+    }
+    return nil;
+}
+
+static BOOL IJSVGiOSXMLChildrenContainTextNodes(NSXMLElement* element)
+{
+    for(NSXMLNode* child in element.children) {
+        if(child.kind == NSXMLTextKind) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static void IJSVGiOSXMLAppendNodeString(NSXMLNode* node,
+                                     NSMutableString* output,
+                                     NSXMLNodeOptions options,
+                                     NSUInteger depth)
+{
+    if(node == nil) {
+        return;
+    }
+    if(node.kind == NSXMLTextKind) {
+        [output appendString:IJSVGiOSXMLEscapeString(node.stringValue ?: @"", NO)];
+        return;
+    }
+    if(node.kind == NSXMLCommentKind) {
+        [output appendFormat:@"<!--%@-->", node.stringValue ?: @""];
+        return;
+    }
+    if(IJSVGiOSXMLNodeIsElement(node) == NO) {
+        return;
+    }
+
+    NSXMLElement* element = (NSXMLElement*)node;
+    NSString* name = element.name ?: element.localName ?: @"node";
+    [output appendFormat:@"<%@", name];
+    for(NSXMLNode* attribute in element.attributes) {
+        NSString* attributeName = attribute.name ?: attribute.localName ?: @"";
+        NSString* attributeValue = IJSVGiOSXMLEscapeString(attribute.stringValue ?: @"", YES);
+        [output appendFormat:@" %@=\"%@\"", attributeName, attributeValue];
+    }
+
+    BOOL hasChildren = element.childCount != 0;
+    if(hasChildren == NO) {
+        if((options & NSXMLNodeCompactEmptyElement) != 0) {
+            [output appendString:@"/>"];
+        } else {
+            [output appendFormat:@"></%@>", name];
+        }
+        return;
+    }
+
+    BOOL prettyPrint = (options & NSXMLNodePrettyPrint) != 0;
+    BOOL containsTextChildren = IJSVGiOSXMLChildrenContainTextNodes(element);
+
+    [output appendString:@">"];
+    if(prettyPrint == YES && containsTextChildren == NO) {
+        [output appendString:@"\n"];
+    }
+    for(NSXMLNode* child in element.children) {
+        if(prettyPrint == YES && containsTextChildren == NO) {
+            for(NSUInteger i = 0; i < depth + 1; i++) {
+                [output appendString:@"  "];
+            }
+        }
+        IJSVGiOSXMLAppendNodeString(child, output, options, depth + 1);
+        if(prettyPrint == YES && containsTextChildren == NO) {
+            [output appendString:@"\n"];
+        }
+    }
+    if(prettyPrint == YES && containsTextChildren == NO) {
+        for(NSUInteger i = 0; i < depth; i++) {
+            [output appendString:@"  "];
+        }
+    }
+    [output appendFormat:@"</%@>", name];
+}
+
+@implementation IJSVGiOSXMLDocument
+
+- (instancetype)init
+{
+    if((self = [super init]) != nil) {
+        _version = @"1.0";
+        _characterEncoding = @"UTF-8";
+    }
+    return self;
+}
+
+- (instancetype)initWithRootElement:(NSXMLElement*)rootElement
+{
+    if((self = [self init]) != nil) {
+        self.rootElement = rootElement;
+    }
+    return self;
+}
+
+- (instancetype)initWithXMLString:(NSString*)string
+                          options:(NSXMLNodeOptions)options
+                            error:(NSError**)error
+{
+    NSData* data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    return [self initWithData:data
+                      options:options
+                        error:error];
+}
+
+- (instancetype)initWithData:(NSData*)data
+                     options:(NSXMLNodeOptions)options
+                       error:(NSError**)error
+{
+    if((self = [self init]) != nil) {
+        if(data.length == 0) {
+            if(error != nil) {
+                *error = [NSError errorWithDomain:@"IJSVGiOSXML"
+                                             code:1001
+                                         userInfo:nil];
+            }
+            return nil;
+        }
+
+        xmlDocPtr doc = xmlReadMemory(data.bytes,
+                                      (int)data.length,
+                                      NULL,
+                                      NULL,
+                                      XML_PARSE_NONET | XML_PARSE_RECOVER | XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+        if(doc == NULL) {
+            if(error != nil) {
+                *error = [NSError errorWithDomain:@"IJSVGiOSXML"
+                                             code:1002
+                                         userInfo:nil];
+            }
+            return nil;
+        }
+
+        xmlNodePtr root = xmlDocGetRootElement(doc);
+        NSXMLNode* rootNode = IJSVGiOSXMLNodeFromLibXMLNode(root, doc);
+        if(IJSVGiOSXMLNodeIsElement(rootNode) == NO) {
+            xmlFreeDoc(doc);
+            if(error != nil) {
+                *error = [NSError errorWithDomain:@"IJSVGiOSXML"
+                                             code:1003
+                                         userInfo:nil];
+            }
+            return nil;
+        }
+
+        self.rootElement = (NSXMLElement*)rootNode;
+        xmlFreeDoc(doc);
+    }
+    return self;
+}
+
+- (instancetype)initWithContentsOfURL:(NSURL*)URL
+                              options:(NSXMLNodeOptions)options
+                                error:(NSError**)error
+{
+    if(URL == nil) {
+        if(error != nil) {
+            *error = [NSError errorWithDomain:@"IJSVGiOSXML"
+                                         code:1005
+                                     userInfo:nil];
+        }
+        return nil;
+    }
+
+    NSData* data = [NSData dataWithContentsOfURL:URL
+                                         options:0
+                                           error:error];
+    if(data == nil) {
+        if(error != nil && *error == nil) {
+            *error = [NSError errorWithDomain:@"IJSVGiOSXML"
+                                         code:1005
+                                     userInfo:nil];
+        }
+        return nil;
+    }
+    return [self initWithData:data
+                      options:options
+                        error:error];
+}
+
+- (void)setRootElement:(NSXMLElement*)rootElement
+{
+    if(_rootElement == rootElement) {
+        return;
+    }
+    _rootElement.parent = nil;
+    _rootElement.document = nil;
+    _rootElement = rootElement;
+    _rootElement.parent = self;
+    _rootElement.document = self;
+}
+
+- (id)rootDocument
+{
+    return self;
+}
+
+- (NSArray<NSXMLElement*>*)nodesForXPath:(NSString*)xPath
+                                   error:(NSError**)error
+{
+    if(_rootElement == nil || xPath.length == 0) {
+        return @[];
+    }
+
+    NSMutableArray<NSXMLElement*>* output = [[NSMutableArray alloc] init];
+    if([xPath isEqualToString:@"//use"] == YES) {
+        IJSVGiOSXMLVisitElements(_rootElement, ^(NSXMLElement* element) {
+            if([element.localName.lowercaseString isEqualToString:@"use"] == YES) {
+                [output addObject:element];
+            }
+        });
+        return output;
+    }
+
+    if([xPath isEqualToString:@"//*[@display='none']"] == YES) {
+        IJSVGiOSXMLVisitElements(_rootElement, ^(NSXMLElement* element) {
+            NSString* value = [element attributeForName:@"display"].stringValue;
+            if([value.lowercaseString isEqualToString:@"none"] == YES) {
+                [output addObject:element];
+            }
+        });
+        return output;
+    }
+
+    if([xPath isEqualToString:@"//defs/*[self::linearGradient or self::radialGradient]"] == YES) {
+        IJSVGiOSXMLVisitElements(_rootElement, ^(NSXMLElement* element) {
+            if([element.localName.lowercaseString isEqualToString:@"defs"] == NO) {
+                return;
+            }
+            for(NSXMLNode* child in element.children) {
+                if(IJSVGiOSXMLNodeIsElement(child) == NO) {
+                    continue;
+                }
+                NSString* localName = ((NSXMLElement*)child).localName.lowercaseString;
+                if([localName isEqualToString:@"lineargradient"] == YES ||
+                   [localName isEqualToString:@"radialgradient"] == YES) {
+                    [output addObject:(NSXMLElement*)child];
+                }
+            }
+        });
+        return output;
+    }
+
+    if([xPath isEqualToString:@"//g"] == YES) {
+        IJSVGiOSXMLVisitElements(_rootElement, ^(NSXMLElement* element) {
+            if([element.localName.lowercaseString isEqualToString:@"g"] == YES) {
+                [output addObject:element];
+            }
+        });
+        return output;
+    }
+
+    if([xPath isEqualToString:@"//path"] == YES) {
+        IJSVGiOSXMLVisitElements(_rootElement, ^(NSXMLElement* element) {
+            if([element.localName.lowercaseString isEqualToString:@"path"] == YES) {
+                [output addObject:element];
+            }
+        });
+        return output;
+    }
+
+    if(error != nil) {
+        *error = [NSError errorWithDomain:@"IJSVGiOSXML"
+                                     code:1004
+                                 userInfo:nil];
+    }
+    return @[];
+}
+
+- (NSString*)XMLStringWithOptions:(NSXMLNodeOptions)options
+{
+    if(_rootElement == nil) {
+        return @"";
+    }
+    NSString* version = _version ?: @"1.0";
+    NSString* charset = _characterEncoding ?: @"UTF-8";
+    NSMutableString* output = [[NSMutableString alloc] initWithFormat:@"<?xml version=\"%@\" encoding=\"%@\"?>",
+                               version,
+                               charset];
+    if((options & NSXMLNodePrettyPrint) != 0) {
+        [output appendString:@"\n"];
+    }
+    IJSVGiOSXMLAppendNodeString(_rootElement, output, options, 0);
+    return output;
+}
+
+@end
+#endif

--- a/Framework/IJSVG/IJSVG/Source/Layers/IJSVGImageLayer.h
+++ b/Framework/IJSVG/IJSVG/Source/Layers/IJSVGImageLayer.h
@@ -11,7 +11,7 @@
 #import <IJSVG/IJSVGTransformLayer.h>
 #import <IJSVG/IJSVGTileLayer.h>
 #import <IJSVG/IJSVGBasicLayer.h>
-#import <AppKit/AppKit.h>
+#import <IJSVG/IJSVGPlatform.h>
 #import <QuartzCore/QuartzCore.h>
 
 @interface IJSVGImageLayer : IJSVGTileLayer {

--- a/Framework/IJSVG/IJSVG/Source/Nodes/IJSVGNode.h
+++ b/Framework/IJSVG/IJSVG/Source/Nodes/IJSVGNode.h
@@ -10,8 +10,7 @@
 #import <IJSVG/IJSVGUnitLength.h>
 #import <IJSVG/IJSVGViewBox.h>
 #import <IJSVG/IJSVGBitFlags64.h>
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
+#import <IJSVG/IJSVGPlatform.h>
 
 @class IJSVGNode;
 @class IJSVG;

--- a/Framework/IJSVG/IJSVG/Source/Parsing/IJSVGParser.h
+++ b/Framework/IJSVG/IJSVG/Source/Parsing/IJSVGParser.h
@@ -27,8 +27,7 @@
 #import <IJSVG/IJSVGUtils.h>
 #import <IJSVG/IJSVGFilter.h>
 #import <IJSVG/IJSVGFilterEffect.h>
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
+#import <IJSVG/IJSVGPlatform.h>
 
 typedef void (^IJSVGNodeParserPostProcessBlock)(void);
 

--- a/Framework/IJSVG/IJSVG/Source/Rendering/IJSVGStyle.h
+++ b/Framework/IJSVG/IJSVG/Source/Rendering/IJSVGStyle.h
@@ -8,8 +8,7 @@
 
 #import <IJSVG/IJSVGTraitedColorStorage.h>
 #import <IJSVG/IJSVGNode.h>
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
+#import <IJSVG/IJSVGPlatform.h>
 #import <objc/runtime.h>
 
 @interface IJSVGStyle : NSObject

--- a/Framework/IJSVG/IJSVG/Source/Utils/IJSVGUtils.h
+++ b/Framework/IJSVG/IJSVG/Source/Utils/IJSVGUtils.h
@@ -9,7 +9,7 @@
 #import <IJSVG/IJSVGCommand.h>
 #import <IJSVG/IJSVGGradientUnitLength.h>
 #import <IJSVG/IJSVGStringAdditions.h>
-#import <Foundation/Foundation.h>
+#import <IJSVG/IJSVGPlatform.h>
 #import <QuartzCore/QuartzCore.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/IJSVGExample/IJSVGExample.xcodeproj/project.pbxproj
+++ b/IJSVGExample/IJSVGExample.xcodeproj/project.pbxproj
@@ -68,6 +68,14 @@
 		59F799E219B880CE00096CB7 /* htc_one.svg in Resources */ = {isa = PBXBuildFile; fileRef = 59F799E119B880CE00096CB7 /* htc_one.svg */; };
 		59FB54BE280B03E600D148FA /* IJSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59FB54B8280B038200D148FA /* IJSVG.framework */; };
 		59FB54C0280B03F400D148FA /* IJSVG.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 59FB54B8280B038200D148FA /* IJSVG.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8074AA7851284F3292425912 /* IJSVGWebKitPSNRTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9249EFD07D92429AB85854A8 /* IJSVGWebKitPSNRTests.m */; };
+		4D23BA8FFA884C3E98BA38BE /* Rectangle.svg in Resources */ = {isa = PBXBuildFile; fileRef = D1FAD87BA04E4647812E90BA /* Rectangle.svg */; };
+		39C73A356E8F499FB14467B7 /* Group.svg in Resources */ = {isa = PBXBuildFile; fileRef = 59D1E39F202279CA00C54672 /* Group.svg */; };
+		F0707854DD2540119836A3C1 /* AJ_Digital_Camera.svg in Resources */ = {isa = PBXBuildFile; fileRef = 590C87F0201FBF27004A1554 /* AJ_Digital_Camera.svg */; };
+		38BC361E85534237916E9D03 /* NewTux.svg in Resources */ = {isa = PBXBuildFile; fileRef = 590C87EE201FA092004A1554 /* NewTux.svg */; };
+		0270C9779423418EAFF4FE87 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 437A1B19AF33427286F28800 /* WebKit.framework */; };
+		D1EF486D0EE64BC0B53BC3E4 /* IJSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59FB54B8280B038200D148FA /* IJSVG.framework */; };
+		E27F4B1D096D483CA4CF0B45 /* IJSVG.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 59FB54B8280B038200D148FA /* IJSVG.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,6 +111,17 @@
 			files = (
 				59FB54C0280B03F400D148FA /* IJSVG.framework in CopyFiles */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2FE908ABD4F740E595BF019B /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E27F4B1D096D483CA4CF0B45 /* IJSVG.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -182,6 +201,9 @@
 		59D6B1A6284F698F0058DE6B /* sh.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sh.svg; sourceTree = "<group>"; };
 		59F799E119B880CE00096CB7 /* htc_one.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = htc_one.svg; sourceTree = "<group>"; };
 		59FB54B3280B038200D148FA /* IJSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = IJSVG.xcodeproj; path = ../Framework/IJSVG/IJSVG.xcodeproj; sourceTree = "<group>"; };
+		9249EFD07D92429AB85854A8 /* IJSVGWebKitPSNRTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IJSVGWebKitPSNRTests.m; sourceTree = "<group>"; };
+		D1FAD87BA04E4647812E90BA /* Rectangle.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Rectangle.svg; sourceTree = "<group>"; };
+		437A1B19AF33427286F28800 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,6 +219,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0270C9779423418EAFF4FE87 /* WebKit.framework in Frameworks */,
+				D1EF486D0EE64BC0B53BC3E4 /* IJSVG.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -246,6 +270,7 @@
 				5986308919BA106D00CF15EA /* SVGExampleView5.m */,
 				59265CE91C4F843E00F333F0 /* SVGExampleView6.h */,
 				59265CEA1C4F843E00F333F0 /* SVGExampleView6.m */,
+				D1FAD87BA04E4647812E90BA /* Rectangle.svg */,
 			);
 			path = IJSVGExample;
 			sourceTree = "<group>";
@@ -312,6 +337,7 @@
 			children = (
 				5956659019B62F4700D805FF /* IJSVGExampleTests.m */,
 				5956658E19B62F4700D805FF /* Supporting Files */,
+				9249EFD07D92429AB85854A8 /* IJSVGWebKitPSNRTests.m */,
 			);
 			path = IJSVGExampleTests;
 			sourceTree = "<group>";
@@ -335,6 +361,7 @@
 		59FB54BD280B03E600D148FA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				437A1B19AF33427286F28800 /* WebKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -368,6 +395,7 @@
 				5956658619B62F4700D805FF /* Sources */,
 				5956658719B62F4700D805FF /* Frameworks */,
 				5956658819B62F4700D805FF /* Resources */,
+				2FE908ABD4F740E595BF019B /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -494,6 +522,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D23BA8FFA884C3E98BA38BE /* Rectangle.svg in Resources */,
+				39C73A356E8F499FB14467B7 /* Group.svg in Resources */,
+				F0707854DD2540119836A3C1 /* AJ_Digital_Camera.svg in Resources */,
+				38BC361E85534237916E9D03 /* NewTux.svg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -521,6 +553,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5956659119B62F4700D805FF /* IJSVGExampleTests.m in Sources */,
+				8074AA7851284F3292425912 /* IJSVGWebKitPSNRTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -658,7 +691,6 @@
 		5956659819B62F4700D805FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -672,14 +704,12 @@
 				INFOPLIST_FILE = IJSVGExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IJSVGExample.app/Contents/MacOS/IJSVGExample";
 			};
 			name = Debug;
 		};
 		5956659919B62F4700D805FF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -689,7 +719,6 @@
 				INFOPLIST_FILE = IJSVGExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IJSVGExample.app/Contents/MacOS/IJSVGExample";
 			};
 			name = Release;
 		};

--- a/IJSVGExample/IJSVGExample.xcodeproj/xcshareddata/xcschemes/IJSVGExample.xcscheme
+++ b/IJSVGExample/IJSVGExample.xcodeproj/xcshareddata/xcschemes/IJSVGExample.xcscheme
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5956657619B62F4600D805FF"
+               BuildableName = "IJSVGExample.app"
+               BlueprintName = "IJSVGExample"
+               ReferencedContainer = "container:IJSVGExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5956658919B62F4700D805FF"
+               BuildableName = "IJSVGExampleTests.xctest"
+               BlueprintName = "IJSVGExampleTests"
+               ReferencedContainer = "container:IJSVGExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5956657619B62F4600D805FF"
+            BuildableName = "IJSVGExample.app"
+            BlueprintName = "IJSVGExample"
+            ReferencedContainer = "container:IJSVGExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5956658919B62F4700D805FF"
+               BuildableName = "IJSVGExampleTests.xctest"
+               BlueprintName = "IJSVGExampleTests"
+               ReferencedContainer = "container:IJSVGExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5956657619B62F4600D805FF"
+            BuildableName = "IJSVGExample.app"
+            BlueprintName = "IJSVGExample"
+            ReferencedContainer = "container:IJSVGExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CG_CONTEXT_SHOW_BACKTRACE"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CG_NUMERICS_SHOW_BACKTRACE"
+            value = "1"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5956657619B62F4600D805FF"
+            BuildableName = "IJSVGExample.app"
+            BlueprintName = "IJSVGExample"
+            ReferencedContainer = "container:IJSVGExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/IJSVGExample/IJSVGExampleTests/IJSVGWebKitPSNRTests.m
+++ b/IJSVGExample/IJSVGExampleTests/IJSVGWebKitPSNRTests.m
@@ -1,0 +1,553 @@
+//
+//  IJSVGWebKitPSNRTests.m
+//  IJSVGExampleTests
+//
+//  Compares IJSVG drawInRect:context: output against WebKit WKWebView snapshots
+//  using PSNR (Peak Signal-to-Noise Ratio) as the quality metric.
+//
+//  Adapted from Sitely's TestIJSVGFilters.m — only the comparison
+//  infrastructure is kept here, plus a few example test cases that use SVGs
+//  already bundled in the IJSVGExample target.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+#import <WebKit/WebKit.h>
+#import <ImageIO/ImageIO.h>
+#import <IJSVG/IJSVG.h>
+
+static const CGFloat kDefaultPSNRThreshold = 30.0;
+static NSString * const kOutputFolder      = @"IJSVGWebKitPSNRResults";
+
+
+#pragma mark - WebKit snapshot helper (navigation delegate)
+
+@interface _IJSVGWebKitSnapshotHelper : NSObject <WKNavigationDelegate>
+@property (nonatomic, copy)   void (^completionBlock)(void);
+@property (nonatomic, assign) BOOL loaded;
+@end
+
+@implementation _IJSVGWebKitSnapshotHelper
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    self.loaded = YES;
+    if (self.completionBlock) {
+        self.completionBlock();
+    }
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation
+      withError:(NSError *)error {
+    NSLog(@"WebKit navigation failed: %@", error);
+    self.loaded = YES;
+    if (self.completionBlock) {
+        self.completionBlock();
+    }
+}
+
+@end
+
+
+#pragma mark - Test class
+
+@interface IJSVGWebKitPSNRTests : XCTestCase
+@end
+
+@implementation IJSVGWebKitPSNRTests
+
+
+#pragma mark - Output directory
+
++ (NSString *)outputDirectory {
+    NSString *override = NSProcessInfo.processInfo.environment[@"IJSVG_OUTPUT_DIR"];
+    if (override.length != 0) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:override
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:nil];
+        return override;
+    }
+    NSString *desktop = [NSSearchPathForDirectoriesInDomains(NSDesktopDirectory, NSUserDomainMask, YES) firstObject];
+    NSString *dir = [desktop stringByAppendingPathComponent:kOutputFolder];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    return dir;
+}
+
++ (NSString *)webKitSandboxHomeDirectory {
+    NSString *dir = [NSTemporaryDirectory() stringByAppendingPathComponent:@"ijsvg-webkit-home"];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager createDirectoryAtPath:[dir stringByAppendingPathComponent:@"Library/Caches/com.apple.dt.xctest.tool/WebKit"]
+           withIntermediateDirectories:YES
+                            attributes:nil
+                                 error:nil];
+    [fileManager createDirectoryAtPath:[dir stringByAppendingPathComponent:@"Library/WebKit"]
+           withIntermediateDirectories:YES
+                            attributes:nil
+                                 error:nil];
+    return dir;
+}
+
++ (NSTimeInterval)webKitRenderSettleDelay {
+    NSString *override = NSProcessInfo.processInfo.environment[@"IJSVG_WEBKIT_SETTLE_DELAY"];
+    if (override.length != 0) {
+        double parsed = override.doubleValue;
+        if (parsed >= 0.0) {
+            return parsed;
+        }
+    }
+    return 2.0;
+}
+
+
+#pragma mark - SVG loading
+
+- (NSString *)svgStringForBundledResource:(NSString *)name {
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *path = [bundle pathForResource:name ofType:@"svg"];
+    if (path == nil) {
+        XCTFail(@"Could not find bundled SVG resource '%@.svg'", name);
+        return nil;
+    }
+    NSError *error = nil;
+    NSString *svg = [NSString stringWithContentsOfFile:path
+                                              encoding:NSUTF8StringEncoding
+                                                 error:&error];
+    if (svg == nil) {
+        NSLog(@"Failed to load SVG %@: %@", path, error);
+    }
+    return svg;
+}
+
+
+#pragma mark - HTML / data URL helpers
+
+- (NSString *)webKitDataURLForSVGString:(NSString *)svgString {
+    NSData *data = [svgString dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *base64 = [data base64EncodedStringWithOptions:0];
+    return [NSString stringWithFormat:@"data:image/svg+xml;charset=utf-8;base64,%@", base64];
+}
+
+- (NSString *)webKitHTMLForImageSource:(NSString *)imageSource size:(CGSize)size {
+    return [NSString stringWithFormat:
+        @"<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        @"<style>html,body{margin:0;padding:0;background:white;overflow:hidden;width:%dpx;height:%dpx;}"
+        @"div.svgcontainer{width:%dpx;height:%dpx;overflow:hidden;}"
+        @"div.svgcontainer img{display:block;width:100%%;height:100%%;}</style>"
+        @"</head><body><div class='svgcontainer'><img src='%@' alt='svg'/></div></body></html>",
+        (int)size.width, (int)size.height,
+        (int)size.width, (int)size.height, imageSource];
+}
+
+- (NSString *)webKitHTMLForInlineSVGString:(NSString *)svgString size:(CGSize)size {
+    return [NSString stringWithFormat:
+        @"<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        @"<style>html,body{margin:0;padding:0;background:white;overflow:hidden;width:%dpx;height:%dpx;}"
+        @"div.svgcontainer{width:%dpx;height:%dpx;overflow:hidden;}"
+        @"div.svgcontainer svg{display:block;width:100%%;height:100%%;}</style>"
+        @"</head><body><div class='svgcontainer'>%@</div></body></html>",
+        (int)size.width, (int)size.height,
+        (int)size.width, (int)size.height, svgString];
+}
+
+- (BOOL)webKitImageElementLoaded:(WKWebView *)webView {
+    __block BOOL loaded = NO;
+    XCTestExpectation *jsExp = [self expectationWithDescription:@"WebKit image state"];
+    NSString *script = @"(function(){var img=document.querySelector('img'); return !!img && img.complete && img.naturalWidth > 0 && img.naturalHeight > 0;})();";
+    [webView evaluateJavaScript:script completionHandler:^(id _Nullable value, NSError * _Nullable error) {
+        if([value isKindOfClass:NSNumber.class]) {
+            loaded = ((NSNumber *)value).boolValue;
+        }
+        [jsExp fulfill];
+    }];
+    [self waitForExpectations:@[jsExp] timeout:10.0];
+    return loaded;
+}
+
+
+#pragma mark - IJSVG rendering (2x bitmap with white background)
+
+- (CGImageRef)renderIJSVG:(NSString *)svgString size:(CGSize)size CF_RETURNS_RETAINED {
+    IJSVG *svg = [[IJSVG alloc] initWithSVGString:svgString];
+    XCTAssertNotNil(svg, @"IJSVG failed to parse SVG string");
+    if (!svg) return NULL;
+
+    svg.renderingBackingScaleHelper = ^CGFloat {
+        return 2.0;
+    };
+
+    NSUInteger pixelW = (NSUInteger)(size.width  * 2);
+    NSUInteger pixelH = (NSUInteger)(size.height * 2);
+
+    CGColorSpaceRef cs = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+    CGContextRef ctx = CGBitmapContextCreate(NULL, pixelW, pixelH, 8,
+                                              pixelW * 4,
+                                              cs,
+                                              kCGImageAlphaPremultipliedLast);
+    CGColorSpaceRelease(cs);
+    if (!ctx) return NULL;
+
+    CGContextSetRGBFillColor(ctx, 1, 1, 1, 1);
+    CGContextFillRect(ctx, CGRectMake(0, 0, pixelW, pixelH));
+
+    CGContextTranslateCTM(ctx, 0, pixelH);
+    CGContextScaleCTM(ctx, 2.0, -2.0);
+
+    [svg drawInRect:CGRectMake(0, 0, size.width, size.height) context:ctx];
+
+    CGImageRef image = CGBitmapContextCreateImage(ctx);
+    CGContextRelease(ctx);
+    return image;
+}
+
+
+#pragma mark - WebKit rendering (snapshot with white background)
+
+- (CGImageRef)renderWebKit:(NSString *)svgString size:(CGSize)size CF_RETURNS_RETAINED {
+    __block CGImageRef resultImage = NULL;
+    NSString *svgDataURLString = [self webKitDataURLForSVGString:svgString];
+
+    void (^work)(void) = ^{
+        static dispatch_once_t onceToken;
+        static NSWindow *window = nil;
+        static WKWebView *webView = nil;
+        static _IJSVGWebKitSnapshotHelper *delegate = nil;
+
+        dispatch_once(&onceToken, ^{
+            NSString *webKitHome = [IJSVGWebKitPSNRTests webKitSandboxHomeDirectory];
+            setenv("CFFIXED_USER_HOME", webKitHome.fileSystemRepresentation, 1);
+            setenv("HOME", webKitHome.fileSystemRepresentation, 1);
+
+            NSRect windowRect = NSMakeRect(-10000, -10000, 256, 256);
+            window = [[NSWindow alloc] initWithContentRect:windowRect
+                                                 styleMask:NSWindowStyleMaskBorderless
+                                                   backing:NSBackingStoreBuffered
+                                                     defer:NO];
+            [window setBackgroundColor:[NSColor whiteColor]];
+
+            WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+            config.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
+            webView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 256, 256)
+                                         configuration:config];
+            [[window contentView] addSubview:webView];
+            [window orderBack:nil];
+
+            delegate = [[_IJSVGWebKitSnapshotHelper alloc] init];
+            webView.navigationDelegate = delegate;
+        });
+
+        [window setFrame:NSMakeRect(-10000, -10000, size.width, size.height) display:NO];
+        webView.frame = NSMakeRect(0, 0, size.width, size.height);
+
+        // Load the SVG via an <img> data URL so WebKit uses its SVG parser
+        // rather than HTML inline-SVG parsing.
+        NSString *html = [self webKitHTMLForImageSource:svgDataURLString
+                                                   size:size];
+
+        XCTestExpectation *loadExp = [self expectationWithDescription:@"WebKit page loaded"];
+        delegate.loaded = NO;
+        delegate.completionBlock = ^{
+            [loadExp fulfill];
+        };
+
+        [webView loadHTMLString:html baseURL:nil];
+        [self waitForExpectations:@[loadExp] timeout:10.0];
+
+        if([self webKitImageElementLoaded:webView] == NO) {
+            // Fall back to inline SVG if <img> didn't load.
+            NSString *fallbackHTML = [self webKitHTMLForInlineSVGString:svgString
+                                                                   size:size];
+            XCTestExpectation *fallbackExp = [self expectationWithDescription:@"WebKit fallback loaded"];
+            delegate.loaded = NO;
+            delegate.completionBlock = ^{
+                [fallbackExp fulfill];
+            };
+            [webView loadHTMLString:fallbackHTML baseURL:nil];
+            [self waitForExpectations:@[fallbackExp] timeout:10.0];
+        }
+
+        NSTimeInterval settleDelay = [IJSVGWebKitPSNRTests webKitRenderSettleDelay];
+        if (settleDelay > 0.0) {
+            XCTestExpectation *renderDelay = [self expectationWithDescription:@"render settle"];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(settleDelay * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                [renderDelay fulfill];
+            });
+            [self waitForExpectations:@[renderDelay] timeout:MAX(10.0, settleDelay + 1.0)];
+        }
+
+        WKSnapshotConfiguration *snapConfig = [[WKSnapshotConfiguration alloc] init];
+        snapConfig.snapshotWidth = @(size.width);
+
+        XCTestExpectation *snapExp = [self expectationWithDescription:@"WebKit snapshot"];
+
+        [webView takeSnapshotWithConfiguration:snapConfig
+                             completionHandler:^(NSImage * _Nullable snapshotImage,
+                                                 NSError * _Nullable error) {
+            if (error) {
+                NSLog(@"Snapshot error: %@", error);
+            }
+            if (snapshotImage) {
+                NSUInteger targetW = (NSUInteger)(size.width * 2);
+                NSUInteger targetH = (NSUInteger)(size.height * 2);
+
+                CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+                CGContextRef bmpCtx = CGBitmapContextCreate(NULL, targetW, targetH, 8,
+                                                             targetW * 4, cs,
+                                                             kCGImageAlphaPremultipliedLast);
+                CGColorSpaceRelease(cs);
+
+                if (bmpCtx) {
+                    CGContextSetRGBFillColor(bmpCtx, 1, 1, 1, 1);
+                    CGContextFillRect(bmpCtx, CGRectMake(0, 0, targetW, targetH));
+
+                    NSGraphicsContext *nsCtx = [NSGraphicsContext graphicsContextWithCGContext:bmpCtx flipped:NO];
+                    [NSGraphicsContext saveGraphicsState];
+                    [NSGraphicsContext setCurrentContext:nsCtx];
+                    [snapshotImage drawInRect:NSMakeRect(0, 0, targetW, targetH)
+                                    fromRect:NSZeroRect
+                                   operation:NSCompositingOperationSourceOver
+                                    fraction:1.0];
+                    [NSGraphicsContext restoreGraphicsState];
+
+                    resultImage = CGBitmapContextCreateImage(bmpCtx);
+                    CGContextRelease(bmpCtx);
+                }
+            }
+            [snapExp fulfill];
+        }];
+
+        [self waitForExpectations:@[snapExp] timeout:10.0];
+    };
+
+    if ([NSThread isMainThread]) {
+        work();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), work);
+    }
+
+    return resultImage;
+}
+
+
+#pragma mark - PSNR computation
+
+- (double)psnrBetweenImageA:(CGImageRef)imageA imageB:(CGImageRef)imageB {
+    if (!imageA || !imageB) return 0.0;
+
+    size_t wA = CGImageGetWidth(imageA);
+    size_t hA = CGImageGetHeight(imageA);
+    size_t wB = CGImageGetWidth(imageB);
+    size_t hB = CGImageGetHeight(imageB);
+
+    size_t w = MIN(wA, wB);
+    size_t h = MIN(hA, hB);
+
+    size_t bytesPerRow = w * 4;
+    size_t bufSize = bytesPerRow * h;
+
+    uint8_t *bufA = (uint8_t *)calloc(1, bufSize);
+    uint8_t *bufB = (uint8_t *)calloc(1, bufSize);
+
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctxA = CGBitmapContextCreate(bufA, w, h, 8, bytesPerRow, cs,
+                                               kCGImageAlphaPremultipliedLast);
+    CGContextRef ctxB = CGBitmapContextCreate(bufB, w, h, 8, bytesPerRow, cs,
+                                               kCGImageAlphaPremultipliedLast);
+    CGColorSpaceRelease(cs);
+
+    CGContextDrawImage(ctxA, CGRectMake(0, 0, w, h), imageA);
+    CGContextDrawImage(ctxB, CGRectMake(0, 0, w, h), imageB);
+
+    CGContextRelease(ctxA);
+    CGContextRelease(ctxB);
+
+    double sumSqDiff = 0.0;
+    NSUInteger pixelCount = 0;
+
+    for (size_t y = 0; y < h; y++) {
+        for (size_t x = 0; x < w; x++) {
+            size_t idx = (y * bytesPerRow) + (x * 4);
+            uint8_t rA = bufA[idx], gA = bufA[idx+1], bA = bufA[idx+2], aA = bufA[idx+3];
+            uint8_t rB = bufB[idx], gB = bufB[idx+1], bB = bufB[idx+2], aB = bufB[idx+3];
+
+            // Only compare pixels where at least one image has alpha > 0
+            if (aA > 0 || aB > 0) {
+                double dr = (double)rA - (double)rB;
+                double dg = (double)gA - (double)gB;
+                double db = (double)bA - (double)bB;
+                double da = (double)aA - (double)aB;
+                sumSqDiff += dr*dr + dg*dg + db*db + da*da;
+                pixelCount++;
+            }
+        }
+    }
+
+    free(bufA);
+    free(bufB);
+
+    if (pixelCount == 0) return 100.0;
+
+    double mse = sumSqDiff / (pixelCount * 4.0);
+    if (mse == 0.0) return 100.0;
+
+    double psnr = 10.0 * log10((255.0 * 255.0) / mse);
+    return psnr;
+}
+
+
+#pragma mark - Diff image generation
+
+- (CGImageRef)diffImageBetweenA:(CGImageRef)imageA B:(CGImageRef)imageB CF_RETURNS_RETAINED {
+    if (!imageA || !imageB) return NULL;
+
+    size_t w = MIN(CGImageGetWidth(imageA), CGImageGetWidth(imageB));
+    size_t h = MIN(CGImageGetHeight(imageA), CGImageGetHeight(imageB));
+    size_t bytesPerRow = w * 4;
+    size_t bufSize = bytesPerRow * h;
+
+    uint8_t *bufA = (uint8_t *)calloc(1, bufSize);
+    uint8_t *bufB = (uint8_t *)calloc(1, bufSize);
+    uint8_t *bufD = (uint8_t *)calloc(1, bufSize);
+
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctxA = CGBitmapContextCreate(bufA, w, h, 8, bytesPerRow, cs,
+                                               kCGImageAlphaPremultipliedLast);
+    CGContextRef ctxB = CGBitmapContextCreate(bufB, w, h, 8, bytesPerRow, cs,
+                                               kCGImageAlphaPremultipliedLast);
+    CGContextRef ctxD = CGBitmapContextCreate(bufD, w, h, 8, bytesPerRow, cs,
+                                               kCGImageAlphaPremultipliedLast);
+    CGColorSpaceRelease(cs);
+
+    CGContextDrawImage(ctxA, CGRectMake(0, 0, w, h), imageA);
+    CGContextDrawImage(ctxB, CGRectMake(0, 0, w, h), imageB);
+
+    CGContextRelease(ctxA);
+    CGContextRelease(ctxB);
+
+    for (size_t i = 0; i < bufSize; i += 4) {
+        int dr = abs((int)bufA[i]   - (int)bufB[i]);
+        int dg = abs((int)bufA[i+1] - (int)bufB[i+1]);
+        int db = abs((int)bufA[i+2] - (int)bufB[i+2]);
+        // Amplify differences for visibility (x4)
+        bufD[i]   = (uint8_t)MIN(255, dr * 4);
+        bufD[i+1] = (uint8_t)MIN(255, dg * 4);
+        bufD[i+2] = (uint8_t)MIN(255, db * 4);
+        bufD[i+3] = 255;
+    }
+
+    CGImageRef diffImage = CGBitmapContextCreateImage(ctxD);
+    CGContextRelease(ctxD);
+
+    free(bufA);
+    free(bufB);
+    free(bufD);
+
+    return diffImage;
+}
+
+
+#pragma mark - PNG saving
+
+- (void)saveCGImage:(CGImageRef)image toPath:(NSString *)path {
+    if (!image) return;
+    NSURL *url = [NSURL fileURLWithPath:path];
+    CGImageDestinationRef dest = CGImageDestinationCreateWithURL((__bridge CFURLRef)url,
+                                                                  CFSTR("public.png"), 1, NULL);
+    if (dest) {
+        CGImageDestinationAddImage(dest, image, NULL);
+        CGImageDestinationFinalize(dest);
+        CFRelease(dest);
+    }
+}
+
+
+#pragma mark - Core comparison
+
+- (void)compareSVGString:(NSString *)svgString
+                    name:(NSString *)name
+                    size:(CGSize)size
+           psnrThreshold:(double)threshold {
+    CGImageRef ijsvgImage = [self renderIJSVG:svgString size:size];
+    XCTAssertTrue(ijsvgImage != NULL, @"IJSVG render failed for %@", name);
+    if (ijsvgImage == NULL) {
+        return;
+    }
+
+    CGImageRef webkitImage = [self renderWebKit:svgString size:size];
+    XCTAssertTrue(webkitImage != NULL, @"WebKit render failed for %@", name);
+    if (webkitImage == NULL) {
+        CGImageRelease(ijsvgImage);
+        return;
+    }
+
+    NSString *outDir = [IJSVGWebKitPSNRTests outputDirectory];
+    [self saveCGImage:ijsvgImage  toPath:[outDir stringByAppendingPathComponent:
+                                          [NSString stringWithFormat:@"%@-ijsvg.png", name]]];
+    [self saveCGImage:webkitImage toPath:[outDir stringByAppendingPathComponent:
+                                          [NSString stringWithFormat:@"%@-webkit.png", name]]];
+
+    CGImageRef diffImage = [self diffImageBetweenA:ijsvgImage B:webkitImage];
+    if (diffImage) {
+        [self saveCGImage:diffImage toPath:[outDir stringByAppendingPathComponent:
+                                            [NSString stringWithFormat:@"%@-diff.png", name]]];
+        CGImageRelease(diffImage);
+    }
+
+    double psnr = [self psnrBetweenImageA:ijsvgImage imageB:webkitImage];
+    NSLog(@"[%@] PSNR = %.2f dB  IJSVG: %zux%zu  WebKit: %zux%zu",
+          name, psnr,
+          CGImageGetWidth(ijsvgImage), CGImageGetHeight(ijsvgImage),
+          CGImageGetWidth(webkitImage), CGImageGetHeight(webkitImage));
+
+    NSString *psnrLine = [NSString stringWithFormat:@"[%@] PSNR = %.2f dB\n", name, psnr];
+    NSString *logPath = [outDir stringByAppendingPathComponent:@"psnr-results.txt"];
+    NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:logPath];
+    if (fh == nil) {
+        [psnrLine writeToFile:logPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    } else {
+        [fh seekToEndOfFile];
+        [fh writeData:[psnrLine dataUsingEncoding:NSUTF8StringEncoding]];
+        [fh closeFile];
+    }
+
+    CGImageRelease(ijsvgImage);
+    CGImageRelease(webkitImage);
+
+    XCTAssertGreaterThanOrEqual(psnr, threshold,
+                                @"%@: PSNR %.2f dB is below threshold %.2f dB",
+                                name, psnr, threshold);
+}
+
+- (void)compareBundledSVG:(NSString *)resourceName
+                     size:(CGSize)size
+            psnrThreshold:(double)threshold {
+    NSString *svg = [self svgStringForBundledResource:resourceName];
+    if (svg == nil) {
+        return;
+    }
+    [self compareSVGString:svg name:resourceName size:size psnrThreshold:threshold];
+}
+
+
+#pragma mark - Example test methods (use SVGs already bundled in IJSVGExample)
+
+- (void)testRectangle {
+    [self compareBundledSVG:@"Rectangle" size:CGSizeMake(256, 256) psnrThreshold:kDefaultPSNRThreshold];
+}
+
+- (void)testGroup {
+    [self compareBundledSVG:@"Group" size:CGSizeMake(256, 256) psnrThreshold:kDefaultPSNRThreshold];
+}
+
+- (void)testAJDigitalCamera {
+    [self compareBundledSVG:@"AJ_Digital_Camera" size:CGSizeMake(256, 256) psnrThreshold:kDefaultPSNRThreshold];
+}
+
+- (void)testNewTux {
+    [self compareBundledSVG:@"NewTux" size:CGSizeMake(256, 256) psnrThreshold:kDefaultPSNRThreshold];
+}
+
+@end


### PR DESCRIPTION
## Summary

Three related changes, kept as one squashed commit so they land together:

### 1. iOS platform abstraction
A new `Source/Core/IJSVGPlatform.{h,m}` centralizes macOS vs iOS differences (AppKit vs UIKit, `NSColor`/`NSImage`/`NSView`/`NSBezierPath`/`NSFont` shims, geometry typedefs and macros, an `NSValue` category bridging NS-named geometry methods to their CG-named iOS counterparts, and a `-setNeedsDisplay:` shim for `UIView`). A new `Source/Core/IJSVGiOSXML.{h,m}` provides a small libxml2-backed `NSXMLNode`/`NSXMLElement`/`NSXMLDocument` replacement for iOS, since Foundation on iOS doesn't ship `NSXML*`.

Headers that previously imported `<AppKit/AppKit.h>` + `<Foundation/Foundation.h>` now import `<IJSVG/IJSVGPlatform.h>` instead. On macOS this is a pure no-op — `IJSVGPlatform.h` just forwards to AppKit + Foundation. On iOS it provides the shims needed for those headers to parse. `IJSVGUmbrella.h` gains entries for the two new public headers.

The PR adds the foundation for iOS support but doesn't claim to make every framework path iOS-clean — call sites that still use macOS-only APIs (`NSPasteboardWriting`, etc.) remain to be guarded in follow-ups. Macos-side everything continues to build and behave exactly as before.

### 2. WebKit/IJSVG PSNR comparison test
A new `IJSVGExampleTests/IJSVGWebKitPSNRTests.m` renders an SVG with both IJSVG and a `WKWebView` snapshot, computes peak signal-to-noise ratio between the two, and writes IJSVG/WebKit/diff PNGs plus a per-run `psnr-results.txt` to the output directory. Useful for visually tracking rendering parity vs the reference browser.

- Override output path: set `IJSVG_OUTPUT_DIR` env var
- Override WebKit render settle delay: set `IJSVG_WEBKIT_SETTLE_DELAY` env var (default 2s)
- Includes four example tests against bundled SVGs (Rectangle, Group, AJ_Digital_Camera, NewTux)

### 3. Standalone (logic) test target
`IJSVGExampleTests` was app-hosted via `TEST_HOST`/`BUNDLE_LOADER`, which launches `IJSVGExample.app` on every test run. This PR drops both settings, links `IJSVG.framework` directly into the test target, and adds an Embed Frameworks copy phase so the `.xctest` bundle is self-contained. SVG resources are copied into the test bundle so tests load them via `[NSBundle bundleForClass:self.class]`. The scheme is promoted from `xcuserdata/` to `xcshareddata/` so `xcodebuild` (and CI) pick it up.

## Test plan

- [x] `xcodebuild -scheme IJSVG -configuration Debug build` (framework target, macOS) — succeeds
- [x] `xcodebuild -scheme IJSVGExample -configuration Debug build-for-testing` — succeeds, produces a self-contained `IJSVGExampleTests.xctest` with `IJSVG.framework` embedded and four SVGs in Resources
- [x] `xcodebuild -scheme IJSVGExample test -only-testing:IJSVGExampleTests/IJSVGWebKitPSNRTests/testGroup` — passes (PSNR 74.55 dB), no app launch
- [ ] iOS build — not validated in this PR; this commit lays the foundation but doesn't claim every call site is iOS-clean yet